### PR TITLE
Add RFQ parsing script and sample output

### DIFF
--- a/parse_rfq.py
+++ b/parse_rfq.py
@@ -1,0 +1,156 @@
+import os
+import json
+import re
+from typing import List
+
+
+FIELDS = [
+    "title",
+    "solicitation number",
+    "agency",
+    "submission deadline",
+    "scope of work",
+    "evaluation criteria",
+    "required qualifications",
+    "submission instructions",
+    "contact information",
+]
+
+
+def extract_section(lines: List[str], start_keywords: List[str], end_keywords: List[str]) -> str:
+    start_idx = None
+    for i, line in enumerate(lines):
+        l = line.lower()
+        if any(k in l for k in start_keywords):
+            start_idx = i + 1
+            break
+    if start_idx is None:
+        return ""
+    collected = []
+    for j in range(start_idx, len(lines)):
+        l = lines[j].strip()
+        if not l:
+            # stop at blank line
+            if collected:
+                break
+            else:
+                continue
+        if any(k in l.lower() for k in end_keywords):
+            break
+        collected.append(l.lstrip('- ').lstrip('•').strip())
+    return " ".join(collected).strip()
+
+
+def parse_rfq(text: str) -> dict:
+    lines = [l.strip() for l in text.splitlines()]
+    data = {field: "" for field in FIELDS}
+
+    # agency: first non-empty line
+    for line in lines:
+        if line:
+            data["agency"] = line
+            break
+
+    # solicitation number
+    for line in lines:
+        if "rfp #" in line.lower():
+            data["solicitation number"] = line.split("#", 1)[1].strip().lstrip(":").strip()
+            break
+
+    # title
+    title_idx = None
+    for i, line in enumerate(lines):
+        if "rfp title" in line.lower():
+            title_text = line.split(":", 1)[1].strip()
+            j = i + 1
+            while j < len(lines):
+                next_line = lines[j].strip()
+                lower = next_line.lower()
+                if not next_line or "due date" in lower or "rfp due" in lower:
+                    break
+                if next_line.endswith(":"):
+                    break
+                title_text += " " + next_line
+                j += 1
+            data["title"] = title_text
+            title_idx = i
+            break
+
+    # submission deadline
+    for line in lines:
+        if "due date" in line.lower():
+            data["submission deadline"] = line.split(":",1)[1].strip()
+            break
+
+    # scope of work (brief scope + deliverables + background)
+    scope = extract_section(
+        lines,
+        ["brief scope of services"],
+        ["evaluation criteria", "proposal requirements"]
+    )
+    if scope:
+        data["scope of work"] = scope
+
+    # evaluation criteria
+    eval_criteria = extract_section(
+        lines,
+        ["evaluation criteria"],
+        ["proposal requirements", "contract duration"]
+    )
+    if eval_criteria:
+        data["evaluation criteria"] = eval_criteria
+
+    # required qualifications - not explicitly present; use proposal requirements if available
+    qualifications = extract_section(
+        lines,
+        ["required qualifications"],
+        ["submission format", "proposal requirements"]
+    )
+    if not qualifications:
+        qualifications = extract_section(
+            lines,
+            ["proposal requirements"],
+            ["contract duration", "submission format"]
+        )
+    if qualifications:
+        data["required qualifications"] = qualifications
+
+    # submission instructions
+    instructions_parts = []
+    for line in lines:
+        if line.lower().startswith("submit to"):
+            instructions_parts.append(line)
+    instr_section = extract_section(
+        lines,
+        ["submission format"],
+        ["compliance"]
+    )
+    if instr_section:
+        instructions_parts.append(instr_section)
+    if instructions_parts:
+        data["submission instructions"] = " ".join(instructions_parts)
+
+    # contact information
+    contacts = []
+    for line in lines:
+        if line.lower().startswith("contact:") or line.lower().startswith("backup contact"):
+            contacts.append(line)
+    if contacts:
+        data["contact information"] = " ".join(contacts)
+
+    return data
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Parse RFQ text into structured data")
+    parser.add_argument("input", help="Path to cleaned txt file")
+    parser.add_argument("output", help="Path to output JSON file")
+    args = parser.parse_args()
+
+    with open(args.input, "r", encoding="utf-8") as f:
+        text = f.read()
+    data = parse_rfq(text)
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)

--- a/structured_output/rfq_25048.json
+++ b/structured_output/rfq_25048.json
@@ -1,0 +1,11 @@
+{
+  "title": "Consultant Services for Portfolio Project Management, Organizational Development and CIP Project Delivery Structure",
+  "solicitation number": "25048",
+  "agency": "City of Bellevue",
+  "submission deadline": "June 10, 2025 at 2:00 PM",
+  "scope of work": "Provide an analysis and recommendations of the current organizational structure versus taking a \u201cPortfolio Approach\u201d for project delivery. Deliverables include analysis, staffing recommendations, performance metrics, and change management plan.",
+  "evaluation criteria": "Experience with CIP and change management \u2013 20 pts Qualifications of team \u2013 20 pts Methodology and understanding of scope \u2013 15 pts Quality assurance and budget control \u2013 15 pts Cost proposal \u2013 5 pts Relevant CIP expertise \u2013 25 pts",
+  "required qualifications": "Cover letter (1 page) Project approach & timeline (3 pages) Cost proposal (1 page) Firm qualifications and past work (3 pages) References (1 page) Signed RFP Form, Non-Collusion Certificate, Equal Opportunity Affidavit",
+  "submission instructions": "Submit To: www.publicpurchase.com One electronic PDF submitted via Public Purchase platform Must be signed by an authorized representative",
+  "contact information": "Contact: Steve Costa \u2013 scosta@bellevuewa.gov Backup Contact: Maher Welaye \u2013 mwelaye@bellevuewa.gov"
+}


### PR DESCRIPTION
## Summary
- add `parse_rfq.py` to semantically parse RFQ text files
- create `structured_output/rfq_25048.json` as an example structured extraction

## Testing
- `python3 parse_rfq.py parsed_text/rfq_25048_clean.txt structured_output/rfq_25048.json`

------
https://chatgpt.com/codex/tasks/task_e_6844ed6338a4832791cec678d304c727